### PR TITLE
Retrofitclient

### DIFF
--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/MockRetrofitCall.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/MockRetrofitCall.java
@@ -1,0 +1,55 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi;
+
+import java.io.IOException;
+
+import okhttp3.Request;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * Created by dmtsc on 4/4/2017.
+ */
+
+public class MockRetrofitCall<T> implements Call<T> {
+    private T mObject;
+
+    public MockRetrofitCall(T object) {
+        this.mObject = object;
+    }
+
+    @Override
+    public Response<T> execute() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void enqueue(Callback<T> callback) {
+        callback.onResponse(this, Response.success(mObject));
+    }
+
+    @Override
+    public boolean isExecuted() {
+        return false;
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    @Override
+    public boolean isCanceled() {
+        return false;
+    }
+
+    @Override
+    public Call clone() {
+        return null;
+    }
+
+    @Override
+    public Request request() {
+        return null;
+    }
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/MockStudyTablesAPIClient.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/MockStudyTablesAPIClient.java
@@ -1,9 +1,0 @@
-package edu.purdue.cs.sigapp.studytables.client.stucytablesapi;
-
-/**
- * Created by dmtsc on 2/23/2017.
- */
-
-public class MockStudyTablesAPIClient {
-
-}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/MockStudytablesApiService.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/MockStudytablesApiService.java
@@ -1,0 +1,80 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi;
+
+import java.util.List;
+
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.Course;
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.Event;
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.LoginResponse;
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.User;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.Path;
+
+/**
+ *  A mock version of the API that returns statically "random" results.
+ *  This does not attempt to persist any information and should not be
+ *  used to test anything other than the "async" execution of events.
+ *
+ *  Callbacks here will be called with success immediately with some sort of "complete"
+ *  though useless information. This will be good for getting the API calls down before
+ *  the server is fully hosted and also for general display and formatting issues
+ *
+ *  Feel free to improve the generation of API data in this class.
+ */
+
+public class MockStudytablesApiService implements StudyTablesAPIClient {
+    @Override
+    public Call<LoginResponse> login(@Body String username, @Body String password) {
+        return new MockRetrofitCall<>(LoginResponse.success());
+    }
+
+    @Override
+    public Call<User> getUserById(@Path("id") String userid) {
+        return new MockRetrofitCall<>(User.randomUser());
+    }
+
+    @Override
+    public Call<User> getUserByUserName(@Path("username") String username) {
+        return new MockRetrofitCall<>(User.randomUser());
+    }
+
+    @Override
+    public Call<User> getSelf() {
+        return new MockRetrofitCall<>(User.randomUser());
+    }
+
+    @Override
+    public Call<User> makeUser(@Body User newUser) {
+        return new MockRetrofitCall<>(newUser);
+    }
+
+    @Override
+    public Call<List<Course>> getCourses() {
+        return new MockRetrofitCall<>(Course.makeRandomClasses());
+    }
+
+    @Override
+    public Call<Course> getCourse(@Path("crn") String crn) {
+        return new MockRetrofitCall<>(Course.makeRandomClasses().get(0));
+    }
+
+    @Override
+    public Call<List<Event>> getEvents() {
+        return new MockRetrofitCall<>(Event.makeRandomEvents());
+    }
+
+    @Override
+    public Call<Event> createEvent(Event event) {
+        return new MockRetrofitCall<>(event);
+    }
+
+    @Override
+    public Call<Event> joinEvent(@Path("id") String eventId) {
+        return new MockRetrofitCall<>(Event.makeRandomEvents().get(0));
+    }
+
+    @Override
+    public Call<Event> leaveEvent(@Path("id") String eventId) {
+        return new MockRetrofitCall<>(Event.makeRandomEvents().get(0));
+    }
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/StudyTablesAPIClient.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/StudyTablesAPIClient.java
@@ -1,0 +1,50 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi;
+
+import java.util.List;
+
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.Course;
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.Event;
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.LoginResponse;
+import edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models.User;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.PUT;
+import retrofit2.http.Path;
+
+/**
+ * Created by dmtsc on 2/23/2017.
+ */
+
+public interface StudyTablesAPIClient {
+
+    @POST("/login")
+    Call<LoginResponse> login(@Body String username, @Body String password);
+
+    @GET("/users/{id}")
+    Call<User> getUserById(@Path("id") String userid);
+    @GET("/users/{username}")
+    Call<User> getUserByUserName(@Path("username") String username);
+    @GET("/users/me")
+    Call<User> getSelf();
+    @POST("/users")
+    Call<User> makeUser(@Body User newUser);
+
+    @GET("/courses")
+    Call<List<Course>> getCourses();
+    @GET("/courses/{crn}")
+    Call<List<Course>> getCourse(@Path("crn") String crn);
+
+    @GET("/events")
+    Call<List<Event>> getEvents();
+    @POST("/events")
+    Call<Event> createEvent(Event event);
+
+    //skipping search by classname.
+
+    @PUT("/events/{id}/join")
+    Call<Event> joinEvent(@Path("id") String eventId);
+    @PUT("/events/{id}/leave")
+    Call<Event> leaveEvent(@Path("id") String eventId);
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/StudyTablesAPIClient.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/StudyTablesAPIClient.java
@@ -34,7 +34,7 @@ public interface StudyTablesAPIClient {
     @GET("/courses")
     Call<List<Course>> getCourses();
     @GET("/courses/{crn}")
-    Call<List<Course>> getCourse(@Path("crn") String crn);
+    Call<Course> getCourse(@Path("crn") String crn);
 
     @GET("/events")
     Call<List<Event>> getEvents();

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Course.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Course.java
@@ -1,0 +1,9 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models;
+
+/**
+ * Created by dmtsc on 4/4/2017.
+ */
+
+public class Course {
+
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Course.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Course.java
@@ -1,9 +1,15 @@
 package edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Created by dmtsc on 4/4/2017.
  */
 
 public class Course {
 
+    public static List<Course> makeRandomClasses() {
+        return Arrays.asList(new Course(), new Course());
+    }
 }

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Event.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Event.java
@@ -5,6 +5,9 @@ import android.location.Location;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalTime;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Created by dmtsc on 2/23/2017.
  */
@@ -14,4 +17,14 @@ public class Event {
     String name;
 
     EventSchedule schedule;
+
+    public Event(String courseId, String name, EventSchedule schedule) {
+        this.courseId = courseId;
+        this.name = name;
+        this.schedule = schedule;
+    }
+
+    public static List<Event> makeRandomEvents() {
+        return Arrays.asList(new Event("123415", "Study Session", null), new Event("86754", "Exam Prep", null));
+    }
 }

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Event.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/Event.java
@@ -10,11 +10,8 @@ import org.joda.time.LocalTime;
  */
 
 public class Event {
-    String title;
-    String location; //consider making this use GPS, optionally.
-    LocalTime time;
-    LocalDate date;
+    String courseId;
+    String name;
 
-    //Need a way to model recurring events.
-    boolean isWeekly = false, isDaily = false, isMonthly = false;
+    EventSchedule schedule;
 }

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/EventSchedule.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/EventSchedule.java
@@ -1,0 +1,11 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models;
+
+/**
+ * Created by dmtsc on 4/4/2017.
+ */
+
+class EventSchedule {
+    String specifictime; //datatime.
+    String repeat; //This is an enum.
+    String endrepeat; //date.
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/LoginResponse.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/LoginResponse.java
@@ -8,4 +8,14 @@ public class LoginResponse {
     boolean success;
     String message;
     String token;
+
+    public LoginResponse(boolean success, String message, String token) {
+        this.success = success;
+        this.message = message;
+        this.token = token;
+    }
+
+    public static LoginResponse success() {
+        return new LoginResponse(true, "You have been logged in", "fake_token_string_123");
+    }
 }

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/LoginResponse.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/LoginResponse.java
@@ -1,0 +1,11 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models;
+
+/**
+ * Created by dmtsc on 4/4/2017.
+ */
+
+public class LoginResponse {
+    boolean success;
+    String message;
+    String token;
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/User.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/User.java
@@ -1,0 +1,14 @@
+package edu.purdue.cs.sigapp.studytables.client.stucytablesapi.models;
+
+/**
+ * Created by dmtsc on 4/4/2017.
+ */
+
+public class User {
+    String username;
+    String name;
+    String email;
+    boolean isVerified;
+    String phoneNumber;
+    //events.
+}

--- a/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/User.java
+++ b/app/src/main/java/edu/purdue/cs/sigapp/studytables/client/stucytablesapi/models/User.java
@@ -10,5 +10,17 @@ public class User {
     String email;
     boolean isVerified;
     String phoneNumber;
+
+    public User(String username, String name, String email, boolean isVerified, String phoneNumber) {
+        this.username = username;
+        this.name = name;
+        this.email = email;
+        this.isVerified = isVerified;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public static User randomUser() {
+        return new User("myusername", "Chuck Norris", "email@example.com", true, "555-5555");
+    }
     //events.
 }


### PR DESCRIPTION
I created a basic retrofit client interface for working with the API before it is fully implemented. 

The calls to the API will likely stay largely the same, but the implementation will be replaced with something more valid once the server project gets a bit more work. 

Feel free to create a Mock*Client that you can make requests against with proper callbacks. Every request will pass with a success code and some form of mocked out data object. Expand on this as necessary. 

@vieck You might be able to use something like this with Dagger for Purdue Laundry testing. No need to mock the OKHttp client. (ie, not have to keep JSON stored on the device at all. You can just send back data like this. I can explain it tonight if you want)